### PR TITLE
Add custom authentication handler for Strava tokens

### DIFF
--- a/Tevling/Authentication/AuthenticationBuilderExtensions.cs
+++ b/Tevling/Authentication/AuthenticationBuilderExtensions.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Authentication;
+
+namespace Tevling.Authentication;
+
+public static class AuthenticationBuilderExtensions
+{
+    public static AuthenticationBuilder AddStravaAuthentication(
+        this AuthenticationBuilder builder,
+        Action<StravaAuthenticationOptions>? configureOptions = null)
+    {
+        builder.AddScheme<StravaAuthenticationOptions, StravaAuthenticationHandler>(
+            StravaAuthenticationDefaults.AuthenticationScheme,
+            null,
+            configureOptions);
+
+        return builder;
+    }
+}

--- a/Tevling/Authentication/StravaAuthenticationDefaults.cs
+++ b/Tevling/Authentication/StravaAuthenticationDefaults.cs
@@ -1,0 +1,6 @@
+namespace Tevling.Authentication;
+
+public static class StravaAuthenticationDefaults
+{
+    public const string AuthenticationScheme = "Strava";
+}

--- a/Tevling/Authentication/StravaAuthenticationHandler.cs
+++ b/Tevling/Authentication/StravaAuthenticationHandler.cs
@@ -1,0 +1,53 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Tevling.Strava;
+
+namespace Tevling.Authentication;
+
+public class StravaAuthenticationHandler(
+    IStravaClient stravaClient,
+    IAthleteService athleteService,
+    IOptionsMonitor<StravaAuthenticationOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<StravaAuthenticationOptions>(options, logger, encoder)
+{
+    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(Options.TokenHeaderName, out StringValues tokenValues) &&
+            !Request.Query.TryGetValue(Options.TokenQueryName, out tokenValues))
+        {
+            return AuthenticateResult.NoResult();
+        }
+
+        string? token = tokenValues.Single();
+
+        if (token is null)
+        {
+            return AuthenticateResult.Fail("Token is null");
+        }
+
+        SummaryAthlete stravaAthlete = await stravaClient.GetAuthenticatedAthleteAsync(token);
+        Athlete? athlete = await athleteService.GetAthleteByStravaIdAsync(stravaAthlete.Id);
+
+        if (athlete is null)
+        {
+            return AuthenticateResult.Fail("Unknown athlete");
+        }
+
+        Claim[] claims =
+        [
+            new(ClaimTypes.Name, athlete.Name),
+            new(ClaimTypes.NameIdentifier, athlete.Id.ToString()),
+        ];
+
+        ClaimsIdentity claimsIdentity = new(claims, Scheme.Name);
+        ClaimsPrincipal claimsPrincipal = new(claimsIdentity);
+        AuthenticationTicket authenticationTicket = new(claimsPrincipal, Scheme.Name);
+
+        return AuthenticateResult.Success(authenticationTicket);
+    }
+}

--- a/Tevling/Authentication/StravaAuthenticationOptions.cs
+++ b/Tevling/Authentication/StravaAuthenticationOptions.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Authentication;
+
+namespace Tevling.Authentication;
+
+public class StravaAuthenticationOptions : AuthenticationSchemeOptions
+{
+    public string TokenHeaderName { get; set; } = "X-Strava-Token";
+    public string TokenQueryName { get; set; } = "token";
+}

--- a/Tevling/Clients/IStravaClient.cs
+++ b/Tevling/Clients/IStravaClient.cs
@@ -25,5 +25,9 @@ public interface IStravaClient
         int? pageSize = null,
         CancellationToken ct = default);
 
+    Task<SummaryAthlete> GetAuthenticatedAthleteAsync(
+        string accessToken,
+        CancellationToken ct = default);
+
     Task DeauthorizeAppAsync(string accessToken, CancellationToken ct = default);
 }

--- a/Tevling/Clients/StravaClient.cs
+++ b/Tevling/Clients/StravaClient.cs
@@ -151,6 +151,24 @@ public class StravaClient : IStravaClient
         }
     }
 
+    public async Task<SummaryAthlete> GetAuthenticatedAthleteAsync(
+        string accessToken,
+        CancellationToken ct = default)
+    {
+        HttpRequestMessage request = new(HttpMethod.Get, "athlete");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        HttpResponseMessage response = await _httpClient.SendAsync(request, ct);
+
+        await ThrowIfUnsuccessful(response, ct);
+
+        string responseBody = await response.Content.ReadAsStringAsync(ct);
+        SummaryAthlete athlete = JsonSerializer.Deserialize<SummaryAthlete>(responseBody) ??
+            throw new Exception("Error deserializing athlete");
+
+        return athlete;
+    }
+
     public async Task DeauthorizeAppAsync(string accessToken, CancellationToken ct = default)
     {
         HttpRequestMessage request = new(HttpMethod.Post, _stravaConfig.DeauthorizeUri);

--- a/Tevling/Controllers/DevController.cs
+++ b/Tevling/Controllers/DevController.cs
@@ -80,6 +80,22 @@ public class DevController : ControllerBase
         return new JsonResult(activities);
     }
 
+    [HttpGet]
+    [Route("strava/athlete")]
+    public IActionResult GetAuthenticatedAthlete()
+    {
+        SummaryAthlete athlete = new()
+        {
+            Id = 1337,
+            Firstname = "Trainer",
+            Lastname = "McTrainface",
+            Profile =
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAMAAAAJbSJIAAAAY1BMVEUDAwP///8AAACOjo7v7+/p6elkZGSdnZ36+vr19fXc3NypqanS0tI0NDSAgICIiIhzc3PExMQmJiYSEhKysrJra2sMDAxLS0uYmJi5ubmkpKRISEhvb28dHR1bW1s5OTnW1tYYldiwAAACt0lEQVR4nO3ca3OiMBSAYXNE8YqX2mrXtu7//5WLdt1uh8CMITkndN7nM5PhLVgYAhmNAAAAAAAAAAAAAAAAAAAAAAAAgDASmXXPd9c92k+rcSyb7TmryHpf3nYzF9mifM+lUeQUPe/Tbp1Do8jHPE3f1cE+UWSZrq9W7I0TRVZJA2tn00SFQOculomJT9FPM8PfonwoBDq3MisUSfhf9H9bq0Q56QS6udF5KpLoQt9UGRW+aQW6hVHhTq3QPZkk6p2kRqep7PUC6/tTi8KpYqHJJVEqxcKJSeFYsbCgULOwKJ+nwaqWK1BOhWXPR2wX771uRoVl31tIecm7sOh/jyybrAtP/fdEJOvC5wh7IkXOhdMYhRMKlVAYPjCFWigMH5hCLRSGD0yhFgq/bfvIGyXDK3z0rZnBFXbN9C/Wvr/I4Ao754k9R3F4hV2BbjP8Qu9DiS8lhRQmROF9MwqbA1OohcL7ZhQ2B6ZQC4X3zShsDkyhFgrvm1HYHJhCLRTeN6OwOTCFWij8t92iq/D4EwrXHYG/fsK8RX2ebsoWniM4xMKu6TXvwMMrfHRgCrVQGD4whVooDB+YQi0Uhg9MoRYKwwfOujDGN9d5f/e0678ncsy6MMJiMvI778L5S78vEFve1cyo0Llx6PexN0ffEcyssN6dSbDWIfMqTMCm0Pe9bio2aypsFQtNFqiRs2JhhOtsQGH3hERcEb4RD0nsnJCIy/twPH1hqRZotCidvKsVLk0CR4pLYVktgNk5bxbTq1FgnXjQKbRbGlJ8S1jEF2OxjeBEjRXNfPPEionpb2zsfoR/Ey+JV96zPYK3xLQL7Vr+Br8St8kWan21X+z6RqRKcYs6W2azKPv1ZYun6rCaFLFMFrvTse1bbyO9Hj+1sG4CAAAAAAAAAAAAAAAAAAAAAADAMP0Bvys1OxI64E0AAAAASUVORK5CYII=",
+        };
+
+        return new JsonResult(athlete);
+    }
+
     [HttpPost]
     [Route("strava/token")]
     public IActionResult StravaTokenEndpoint()

--- a/Tevling/Program.cs
+++ b/Tevling/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.FeatureManagement;
 using Serilog;
 using Serilog.Events;
+using Tevling.Authentication;
 
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
@@ -50,7 +51,8 @@ builder.Services
         {
             options.LoginPath = "/login";
             options.ReturnUrlParameter = "returnUrl";
-        });
+        })
+    .AddStravaAuthentication();
 
 // Make sure our data directoy used to store the SQLite DB file exists.
 string dataDir = Path.Join(Environment.CurrentDirectory, "storage");

--- a/Tevling/Services/AthleteService.cs
+++ b/Tevling/Services/AthleteService.cs
@@ -28,6 +28,15 @@ public class AthleteService(
         return athlete;
     }
 
+    public async Task<Athlete?> GetAthleteByStravaIdAsync(long stravaId, CancellationToken ct = default)
+    {
+        await using DataContext dataContext = await dataContextFactory.CreateDbContextAsync(ct);
+
+        Athlete? athlete = await dataContext.Athletes.FirstOrDefaultAsync(a => a.StravaId == stravaId, ct);
+
+        return athlete;
+    }
+
     public async Task<Athlete[]> GetAthletesAsync(
         AthleteFilter? filter = null,
         Paging? paging = null,

--- a/Tevling/Services/IAthleteService.cs
+++ b/Tevling/Services/IAthleteService.cs
@@ -3,6 +3,7 @@ namespace Tevling.Services;
 public interface IAthleteService
 {
     Task<Athlete?> GetAthleteByIdAsync(int athleteId, CancellationToken ct = default);
+    Task<Athlete?> GetAthleteByStravaIdAsync(long stravaId, CancellationToken ct = default);
 
     Task<Athlete[]> GetAthletesAsync(
         AthleteFilter? filter = null,


### PR DESCRIPTION
Making it possible to authenticate with the API using a Strava token, either passed by header `X-Strava-Token` or query parameter `token`.

The token will be used in an athlete lookup towards the Strava API and the user is authenticated if that Strava athlete exists in Tevling's DB.

To protect an endpoint/controller and require a Strava token, simply add this attribute:

`[Authorize(AuthenticationSchemes = StravaAuthenticationDefaults.AuthenticationScheme)]`