### PR TITLE
Dev/challenge api

### DIFF
--- a/Tevling/Controllers/ChallengeController.cs
+++ b/Tevling/Controllers/ChallengeController.cs
@@ -7,33 +7,33 @@ namespace Tevling.Controllers;
 [ApiController]
 [Route("challenges")]
 [FeatureGate(FeatureFlag.EnableChallengeApi)]
-public class ChallengeController : ControllerBase
+public class ChallengeController(IChallengeService challengeService) : ControllerBase
 {
-    public ChallengeController()
-    {
-    }
-
     [HttpGet]
     [Route("scoreboard/{stravaId}")]
-    public IActionResult GetChallenges(long stravaId)
+    public async Task<IActionResult> GetChallenges(int stravaId, CancellationToken ct = default)
     {
-        List<AthleteScore> scores =
-        [
-            new AthleteScore(
-                "Fjomp1",
-               "23"
-            ),
-
-            new AthleteScore(
-                "Fjomp2",
-                "30"
-            ),
-
-        ];
-        ScoreBoard scoreBoard = new
-        (
-            scores
+        ChallengeFilter filter = new(
+            string.Empty,
+            stravaId,
+            OnlyJoinedChallenges: true,
+            IncludeOutdatedChallenges: false
         );
-        return new JsonResult(scoreBoard);
+
+        Challenge[] challenges = await challengeService.GetChallengesAsync(stravaId, filter, null, ct);
+
+        var output = await Task.WhenAll(
+            challenges.Select(async c =>
+            {
+                ScoreBoard scoreboard = await challengeService.GetScoreBoardAsync(c.Id, ct);
+                return new
+                {
+                    challengeTitle = c.Title,
+                    scores = scoreboard.Scores,
+                };
+            })
+        );
+
+        return new JsonResult(output);
     }
 }

--- a/Tevling/Controllers/ChallengeController.cs
+++ b/Tevling/Controllers/ChallengeController.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
+using RouteAttribute = Microsoft.AspNetCore.Mvc.RouteAttribute;
+
+namespace Tevling.Controllers;
+
+[ApiController]
+[Route("challenges")]
+[FeatureGate(FeatureFlag.EnableChallengeApi)]
+public class ChallengeController : ControllerBase
+{
+    public ChallengeController()
+    {
+    }
+
+    [HttpGet]
+    [Route("scoreboard/{stravaId}")]
+    public IActionResult GetChallenges(long stravaId)
+    {
+        List<AthleteScore> scores =
+        [
+            new AthleteScore(
+                "Fjomp1",
+               "23"
+            ),
+
+            new AthleteScore(
+                "Fjomp2",
+                "30"
+            ),
+
+        ];
+        ScoreBoard scoreBoard = new
+        (
+            scores
+        );
+        return new JsonResult(scoreBoard);
+    }
+}

--- a/Tevling/Controllers/ChallengesController.cs
+++ b/Tevling/Controllers/ChallengesController.cs
@@ -11,7 +11,7 @@ namespace Tevling.Controllers;
 [Route("challenges")]
 [FeatureGate(FeatureFlag.EnableChallengeApi)]
 [Authorize(AuthenticationSchemes = StravaAuthenticationDefaults.AuthenticationScheme)]
-public class ChallengeController(IChallengeService challengeService) : ControllerBase
+public class ChallengesController(IChallengeService challengeService) : ControllerBase
 {
     [HttpGet]
     [Route("scoreboard")]

--- a/Tevling/Controllers/ChallengesController.cs
+++ b/Tevling/Controllers/ChallengesController.cs
@@ -9,7 +9,7 @@ namespace Tevling.Controllers;
 
 [ApiController]
 [Route("api/challenges")]
-[FeatureGate(FeatureFlag.EnableChallengeApi)]
+[FeatureGate(FeatureFlag.ChallengesApi)]
 [Authorize(AuthenticationSchemes = StravaAuthenticationDefaults.AuthenticationScheme)]
 public class ChallengesController(IChallengeService challengeService) : ControllerBase
 {

--- a/Tevling/Controllers/ChallengesController.cs
+++ b/Tevling/Controllers/ChallengesController.cs
@@ -8,7 +8,7 @@ using RouteAttribute = Microsoft.AspNetCore.Mvc.RouteAttribute;
 namespace Tevling.Controllers;
 
 [ApiController]
-[Route("challenges")]
+[Route("api/challenges")]
 [FeatureGate(FeatureFlag.EnableChallengeApi)]
 [Authorize(AuthenticationSchemes = StravaAuthenticationDefaults.AuthenticationScheme)]
 public class ChallengesController(IChallengeService challengeService) : ControllerBase

--- a/Tevling/FeatureFlag.cs
+++ b/Tevling/FeatureFlag.cs
@@ -8,7 +8,7 @@ public sealed class FeatureFlag
     // NB! These names should match those in appsettings.json.
     public const string DevTools = "DevTools";
     public const string DevToolsMenuItem = "DevToolsMenuItem";
-    public const string EnableChallengeApi = "EnableChallengeApi";
+    public const string ChallengesApi = "ChallengesApi";
 
     private readonly string _featureFlag;
 

--- a/Tevling/FeatureFlag.cs
+++ b/Tevling/FeatureFlag.cs
@@ -8,6 +8,7 @@ public sealed class FeatureFlag
     // NB! These names should match those in appsettings.json.
     public const string DevTools = "DevTools";
     public const string DevToolsMenuItem = "DevToolsMenuItem";
+    public const string EnableChallengeApi = "EnableChallengeApi";
 
     private readonly string _featureFlag;
 

--- a/Tevling/appsettings.Development.json
+++ b/Tevling/appsettings.Development.json
@@ -10,6 +10,6 @@
   "FeatureManagement": {
     "DevTools": true,
     "DevToolsMenuItem": true,
-    "EnableChallengeApi": true
+    "ChallengesApi": true
   }
 }

--- a/Tevling/appsettings.Development.json
+++ b/Tevling/appsettings.Development.json
@@ -9,6 +9,7 @@
   },
   "FeatureManagement": {
     "DevTools": true,
-    "DevToolsMenuItem": true
+    "DevToolsMenuItem": true,
+    "EnableChallengeApi": true
   }
 }

--- a/Tevling/appsettings.json
+++ b/Tevling/appsettings.json
@@ -62,6 +62,7 @@
   },
   "FeatureManagement": {
     "DevTools": false,
-    "DevToolsMenuItem": false
+    "DevToolsMenuItem": false,
+    "EnableChallengeApi": true
   }
 }

--- a/Tevling/appsettings.json
+++ b/Tevling/appsettings.json
@@ -63,6 +63,6 @@
   "FeatureManagement": {
     "DevTools": false,
     "DevToolsMenuItem": false,
-    "EnableChallengeApi": true
+    "ChallengesApi": false
   }
 }


### PR DESCRIPTION
### WHAT
Add a `/challenges` REST API with a `/scoreboard` endpoint which returns the leaderboard for all active challenges that the user has joined

### WHY
So that a user can get the scoreboard information for the challenges he/she has joined. The plan is create a Garmin app where you can view the Tevling scoreboards

### HOW
1. Find your Strava acces token
2.   Get your Strava ID
```
curl --location 'https://www.strava.com/api/v3/athlete' \
--header 'Authorization: Bearer ACCESS_TOKEN'
```
3. Add your user to the `Athletes` table in the db
4. Change the appsettings `BaseApiUri` to be the actual Strava uri
5. Run the Tevling app
-- Maybe add a challenge or two
7. `curl http://localhost:5134/challenges/scoreboard?token=ACCESS_TOKEN`
8. Verify that you get scoreboards for your active challenges