### PR TITLE
Fix time accumolation

### DIFF
--- a/Tevling/Components/ChallengeCard.razor.cs
+++ b/Tevling/Components/ChallengeCard.razor.cs
@@ -63,8 +63,8 @@ public partial class ChallengeCard : ComponentBase
 
     private async Task DrawStats()
     {
-        List<string> users = ScoreBoard!.Scores.Select(score => score.Name).ToList();
-        List<float> data = ScoreBoard!.Scores.Select(score => score.ScoreValue).ToList();
+        List<string> users = [.. ScoreBoard!.Scores.Select(score => score.Name)];
+        List<float> data = [.. ScoreBoard!.Scores.Select(score => score.ScoreValue)];
         
         await JSRuntime.InvokeVoidAsync(
             "DrawChallengeStats",

--- a/Tevling/Pages/Statistics.razor.cs
+++ b/Tevling/Pages/Statistics.razor.cs
@@ -22,7 +22,7 @@ public partial class Statistics : ComponentBase, IAsyncDisposable
     protected override async Task OnInitializedAsync()
     {
         _athlete = await AuthenticationService.GetCurrentAthleteAsync();
-        UpdateMeasurementData();
+        await UpdateMeasurementData();
     }
 
     private Dictionary<string, float[]> GetAggregatedMeasurementData(Func<Activity, float> selector, int monthCount = 3)
@@ -95,7 +95,7 @@ public partial class Statistics : ComponentBase, IAsyncDisposable
 
         string[] months = CreateMonthArray(NumberOfMonthsToReview);
 
-        UpdateMeasurementData();
+        await UpdateMeasurementData();
 
         switch (Measurement)
         {

--- a/Tevling/Services/ChallengeService.cs
+++ b/Tevling/Services/ChallengeService.cs
@@ -356,7 +356,7 @@ public class ChallengeService(
                     float scoreValue = challenge.Measurement switch
                     {
                         ChallengeMeasurement.Distance => s.Sum / 1000,
-                        ChallengeMeasurement.Time => TimeSpan.FromSeconds(s.Sum).Hours,
+                        ChallengeMeasurement.Time => (float)TimeSpan.FromSeconds(s.Sum).TotalHours,
                         ChallengeMeasurement.Elevation => s.Sum,
                         _ => s.Sum,
                     };


### PR DESCRIPTION
### WHAT
Use the `TotalHours` property of the `TimeSpan` , not `Hours`

### WHY
Bugfix - The challenge stats for time challenges was wrong

### HOW
1. Checkout this branch and run it
2. Create a time challenge
3. Add enough activities such that the time elapsed for an athlete becomes more than 24 hours
4. Verify that the stats does **NOT** circle the 24 hour interval


