### PR TITLE
Fix Statistics page header styling

### DIFF
--- a/Tevling/Pages/Statistics.razor.css
+++ b/Tevling/Pages/Statistics.razor.css
@@ -1,0 +1,5 @@
+.title {
+  letter-spacing: 0.2rem;
+  font-variant: all-small-caps;
+  font-size: xxx-large;
+}


### PR DESCRIPTION
### WHAT
Fix Statistics page header styling

### WHY
So that it reflects the same title styling as the other pages

### HOW
Run this version and verify that the statistics page title has the same styling as the other pages