### PR TITLE
Reduce goal step to 1 hour for time challenges

### DIFF
--- a/Tevling/Components/ChallengeForm.razor.cs
+++ b/Tevling/Components/ChallengeForm.razor.cs
@@ -44,7 +44,7 @@ public partial class ChallengeForm : ComponentBase
     private string GoalStep => Challenge.Measurement switch
     {
         ChallengeMeasurement.Distance => "10",
-        ChallengeMeasurement.Time => "10",
+        ChallengeMeasurement.Time => "1",
         ChallengeMeasurement.Elevation => "100",
         ChallengeMeasurement.Calories => "100",
         _ => "1",


### PR DESCRIPTION
# WHAT
Reduced goal step to 1 hour instead of 10 for time challenges

# WHY
Want to be able to set a goal of 24 hours, which was not possible since the goal step was set to 10

# HOW
Reduced goal step for time challenge