### PR TITLE
"Not Found" rate limiter middleware

### DIFF
--- a/Tevling.Tests/RateLimiting/NotFoundRateLimitTrackerTest.cs
+++ b/Tevling.Tests/RateLimiting/NotFoundRateLimitTrackerTest.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Tevling.RateLimiting;
+
+public class NotFoundRateLimitTrackerTest
+{
+    private const string ClientKey = "127.0.0.1";
+    private const string CacheKey = "not-found-rate-limit:" + ClientKey;
+
+    [Fact]
+    public async Task IsExceededAsync_Should_Return_False_When_No_Entries_Exist()
+    {
+        IDistributedCache cache = CreateCache();
+        NotFoundRateLimitTracker sut = CreateSut(cache);
+
+        bool exceeded = await sut.IsExceededAsync(ClientKey, TestContext.Current.CancellationToken);
+
+        exceeded.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task IsExceededAsync_Should_Return_False_When_Below_Limit()
+    {
+        IDistributedCache cache = CreateCache();
+        NotFoundRateLimitTracker sut = CreateSut(cache, maxNotFoundRequests: 3);
+
+        for (int i = 0; i < 3; i++)
+        {
+            await sut.RegisterNotFoundAsync(ClientKey, TestContext.Current.CancellationToken);
+        }
+
+        bool exceeded = await sut.IsExceededAsync(ClientKey, TestContext.Current.CancellationToken);
+
+        exceeded.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task IsExceededAsync_Should_Return_False_When_At_Limit()
+    {
+        IDistributedCache cache = CreateCache();
+        NotFoundRateLimitTracker sut = CreateSut(cache, maxNotFoundRequests: 3);
+
+        for (int i = 0; i < 3; i++)
+        {
+            await sut.RegisterNotFoundAsync(ClientKey, TestContext.Current.CancellationToken);
+        }
+
+        bool exceeded = await sut.IsExceededAsync(ClientKey, TestContext.Current.CancellationToken);
+
+        exceeded.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task IsExceededAsync_Should_Return_True_When_Above_Limit()
+    {
+        IDistributedCache cache = CreateCache();
+        NotFoundRateLimitTracker sut = CreateSut(cache, maxNotFoundRequests: 3);
+
+        for (int i = 0; i < 4; i++)
+        {
+            await sut.RegisterNotFoundAsync(ClientKey, TestContext.Current.CancellationToken);
+        }
+
+        bool exceeded = await sut.IsExceededAsync(ClientKey, TestContext.Current.CancellationToken);
+
+        exceeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task IsExceededAsync_Should_Ignore_Entries_Outside_Window()
+    {
+        IDistributedCache cache = CreateCache();
+        TimeSpan window = TimeSpan.FromMinutes(1);
+        NotFoundRateLimitTracker sut = CreateSut(cache, maxNotFoundRequests: 2, window: window);
+
+        DateTime now = DateTime.UtcNow;
+        List<DateTime> seeded =
+        [
+            now.AddMinutes(-5),
+            now.AddMinutes(-4),
+            now.AddMinutes(-3),
+            now.AddMinutes(-2),
+            now.AddSeconds(-30),
+        ];
+        await cache.SetAsync(
+            CacheKey,
+            JsonSerializer.SerializeToUtf8Bytes(seeded),
+            new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1) },
+            TestContext.Current.CancellationToken);
+
+        bool exceeded = await sut.IsExceededAsync(ClientKey, TestContext.Current.CancellationToken);
+
+        exceeded.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task IsExceededAsync_Should_Count_Only_Entries_Within_Window()
+    {
+        IDistributedCache cache = CreateCache();
+        TimeSpan window = TimeSpan.FromMinutes(1);
+        NotFoundRateLimitTracker sut = CreateSut(cache, maxNotFoundRequests: 2, window: window);
+
+        DateTime now = DateTime.UtcNow;
+        List<DateTime> seeded =
+        [
+            now.AddMinutes(-5),
+            now.AddSeconds(-30),
+            now.AddSeconds(-20),
+            now.AddSeconds(-10),
+        ];
+        await cache.SetAsync(
+            CacheKey,
+            JsonSerializer.SerializeToUtf8Bytes(seeded),
+            new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1) },
+            TestContext.Current.CancellationToken);
+
+        bool exceeded = await sut.IsExceededAsync(ClientKey, TestContext.Current.CancellationToken);
+
+        exceeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task RegisterNotFoundAsync_Should_Append_Timestamp()
+    {
+        IDistributedCache cache = CreateCache();
+        NotFoundRateLimitTracker sut = CreateSut(cache);
+
+        DateTime before = DateTime.UtcNow;
+        await sut.RegisterNotFoundAsync(ClientKey, TestContext.Current.CancellationToken);
+        DateTime after = DateTime.UtcNow;
+
+        List<DateTime> stored = await ReadCache(cache);
+        stored.Count.ShouldBe(1);
+        stored[0].ShouldBeInRange(before, after);
+    }
+
+    [Fact]
+    public async Task RegisterNotFoundAsync_Should_Append_To_Existing_Timestamps()
+    {
+        IDistributedCache cache = CreateCache();
+        NotFoundRateLimitTracker sut = CreateSut(cache);
+
+        await sut.RegisterNotFoundAsync(ClientKey, TestContext.Current.CancellationToken);
+        await sut.RegisterNotFoundAsync(ClientKey, TestContext.Current.CancellationToken);
+        await sut.RegisterNotFoundAsync(ClientKey, TestContext.Current.CancellationToken);
+
+        List<DateTime> stored = await ReadCache(cache);
+        stored.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task RegisterNotFoundAsync_Should_Prune_Entries_Outside_Window()
+    {
+        IDistributedCache cache = CreateCache();
+        TimeSpan window = TimeSpan.FromMinutes(1);
+        NotFoundRateLimitTracker sut = CreateSut(cache, window: window);
+
+        DateTime now = DateTime.UtcNow;
+        List<DateTime> seeded =
+        [
+            now.AddMinutes(-5),
+            now.AddMinutes(-2),
+            now.AddSeconds(-30),
+        ];
+        await cache.SetAsync(
+            CacheKey,
+            JsonSerializer.SerializeToUtf8Bytes(seeded),
+            new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1) },
+            TestContext.Current.CancellationToken);
+
+        await sut.RegisterNotFoundAsync(ClientKey, TestContext.Current.CancellationToken);
+
+        List<DateTime> stored = await ReadCache(cache);
+        stored.Count.ShouldBe(2);
+        stored.ShouldNotContain(seeded[0]);
+        stored.ShouldNotContain(seeded[1]);
+        stored.ShouldContain(seeded[2]);
+    }
+
+    [Fact]
+    public async Task Tracker_Should_Isolate_Different_Client_Keys()
+    {
+        IDistributedCache cache = CreateCache();
+        NotFoundRateLimitTracker sut = CreateSut(cache, maxNotFoundRequests: 1);
+
+        await sut.RegisterNotFoundAsync("client-a", TestContext.Current.CancellationToken);
+        await sut.RegisterNotFoundAsync("client-a", TestContext.Current.CancellationToken);
+        await sut.RegisterNotFoundAsync("client-a", TestContext.Current.CancellationToken);
+
+        bool aExceeded = await sut.IsExceededAsync("client-a", TestContext.Current.CancellationToken);
+        bool bExceeded = await sut.IsExceededAsync("client-b", TestContext.Current.CancellationToken);
+
+        aExceeded.ShouldBeTrue();
+        bExceeded.ShouldBeFalse();
+    }
+
+    private static async Task<List<DateTime>> ReadCache(IDistributedCache cache)
+    {
+        byte[]? bytes = await cache.GetAsync(CacheKey, TestContext.Current.CancellationToken);
+        bytes.ShouldNotBeNull();
+        List<DateTime>? timestamps = JsonSerializer.Deserialize<List<DateTime>>(bytes);
+        timestamps.ShouldNotBeNull();
+        return timestamps;
+    }
+
+    private static IDistributedCache CreateCache() =>
+        new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+
+    private static NotFoundRateLimitTracker CreateSut(
+        IDistributedCache cache,
+        int maxNotFoundRequests = 20,
+        TimeSpan? window = null) =>
+        new(
+            cache,
+            Options.Create(
+                new NotFoundRateLimitOptions
+                {
+                    MaxNotFoundRequests = maxNotFoundRequests,
+                    Window = window ?? TimeSpan.FromMinutes(1),
+                }));
+}

--- a/Tevling/Program.cs
+++ b/Tevling/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.FeatureManagement;
 using Serilog;
 using Serilog.Events;
 using Tevling.Authentication;
+using Tevling.RateLimiting;
 
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
@@ -40,6 +41,7 @@ builder.Services.AddFeatureManagement();
 builder.Services.AddHealthChecks();
 builder.Services.AddLocalization();
 builder.Services.AddTokenRefresh();
+builder.Services.AddNotFoundRateLimit(builder.Configuration);
 builder.Services.AddOutputCache();
 
 builder.Services.Configure<StravaConfig>(builder.Configuration.GetSection(nameof(StravaConfig)));
@@ -98,6 +100,7 @@ builder.Services.AddHostedService<BatchImportService>();
 
 WebApplication app = builder.Build();
 
+app.UseNotFoundRateLimit();
 app.UseStaticFiles();
 app.UseSerilogRequestLogging();
 app.UseRouting();

--- a/Tevling/RateLimiting/ApplicationBuilderExtensions.cs
+++ b/Tevling/RateLimiting/ApplicationBuilderExtensions.cs
@@ -1,0 +1,10 @@
+namespace Tevling.RateLimiting;
+
+public static class ApplicationBuilderExtensions
+{
+    public static IApplicationBuilder UseNotFoundRateLimit(this IApplicationBuilder builder)
+    {
+        builder.UseMiddleware<NotFoundRateLimitMiddleware>();
+        return builder;
+    }
+}

--- a/Tevling/RateLimiting/NotFoundRateLimitMiddleware.cs
+++ b/Tevling/RateLimiting/NotFoundRateLimitMiddleware.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Options;
+
+namespace Tevling.RateLimiting;
+
+public class NotFoundRateLimitMiddleware(
+    NotFoundRateLimitTracker tracker,
+    IOptions<NotFoundRateLimitOptions> options,
+    ILogger<NotFoundRateLimitMiddleware> logger)
+    : IMiddleware
+{
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        // NB: If the app lies behind a proxy, the IP address will be that of the proxy.
+        // To solve this, the proxy must be configured to forward the client IP
+        // and this app must make use of the ForwardedHeaders middleware.
+        string clientKey = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+        if (await tracker.IsExceededAsync(clientKey, context.RequestAborted))
+        {
+            logger.LogWarning(
+                "\"Not-found\" rate limit exceeded for {Client} on {Path}",
+                clientKey,
+                context.Request.Path);
+
+            context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+            context.Response.Headers.RetryAfter =
+                ((int)options.Value.Window.TotalSeconds).ToString();
+            return;
+        }
+
+        context.Response.OnStarting(async () =>
+        {
+            if (context.Response.StatusCode == StatusCodes.Status404NotFound)
+                await tracker.RegisterNotFoundAsync(clientKey, context.RequestAborted);
+        });
+
+        await next(context);
+    }
+}

--- a/Tevling/RateLimiting/NotFoundRateLimitOptions.cs
+++ b/Tevling/RateLimiting/NotFoundRateLimitOptions.cs
@@ -1,0 +1,7 @@
+namespace Tevling.RateLimiting;
+
+public class NotFoundRateLimitOptions
+{
+    public int MaxNotFoundRequests { get; init; } = 20;
+    public TimeSpan Window { get; init; } = TimeSpan.FromMinutes(1);
+}

--- a/Tevling/RateLimiting/NotFoundRateLimitTracker.cs
+++ b/Tevling/RateLimiting/NotFoundRateLimitTracker.cs
@@ -1,0 +1,52 @@
+using System.Text.Json;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Options;
+
+namespace Tevling.RateLimiting;
+
+public class NotFoundRateLimitTracker(
+    IDistributedCache cache,
+    IOptions<NotFoundRateLimitOptions> options)
+{
+    private const string KeyPrefix = "not-found-rate-limit:";
+    private readonly NotFoundRateLimitOptions _options = options.Value;
+
+    public async Task<bool> IsExceededAsync(
+        string clientKey,
+        CancellationToken cancellationToken = default)
+    {
+        string key = KeyPrefix + clientKey;
+        DateTime cutoff = DateTime.UtcNow - _options.Window;
+
+        byte[]? existing = await cache.GetAsync(key, cancellationToken);
+        if (existing is null) return false;
+
+        List<DateTime>? timestamps = JsonSerializer.Deserialize<List<DateTime>>(existing);
+        if (timestamps is null) return false;
+
+        return timestamps.Count(t => t >= cutoff) > _options.MaxNotFoundRequests;
+    }
+
+    public async Task RegisterNotFoundAsync(
+        string clientKey,
+        CancellationToken cancellationToken = default)
+    {
+        string key = KeyPrefix + clientKey;
+        DateTime now = DateTime.UtcNow;
+        DateTime cutoff = now - _options.Window;
+
+        byte[]? existing = await cache.GetAsync(key, cancellationToken);
+        List<DateTime> timestamps = existing is null
+            ? []
+            : JsonSerializer.Deserialize<List<DateTime>>(existing) ?? [];
+
+        timestamps.RemoveAll(t => t < cutoff);
+        timestamps.Add(now);
+
+        await cache.SetAsync(
+            key,
+            JsonSerializer.SerializeToUtf8Bytes(timestamps),
+            new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = _options.Window },
+            cancellationToken);
+    }
+}

--- a/Tevling/RateLimiting/ServiceCollectionExtensions.cs
+++ b/Tevling/RateLimiting/ServiceCollectionExtensions.cs
@@ -1,0 +1,16 @@
+namespace Tevling.RateLimiting;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddNotFoundRateLimit(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<NotFoundRateLimitOptions>(
+            configuration.GetSection(nameof(NotFoundRateLimitOptions)));
+        services.AddDistributedMemoryCache(); // NB: Use another distributed cache provider if we need to run multiple instances
+        services.AddSingleton<NotFoundRateLimitTracker>();
+        services.AddTransient<NotFoundRateLimitMiddleware>();
+        return services;
+    }
+}

--- a/Tevling/appsettings.json
+++ b/Tevling/appsettings.json
@@ -68,5 +68,9 @@
   "AdminIds": [
   ],
   "CultureByHost": {
+  },
+  "NotFoundRateLimitOptions": {
+    "MaxNotFoundRequests": 10,
+    "Window": "00:01:00"
   }
 }


### PR DESCRIPTION
### WHAT
"Not Found" rate limiter middleware. The middleware it self is a two-parter. 

It first checks if the incoming request comes from an IP which has exceeded the rate limit filter. If the limit is exceeded it immediately return `429`. I.e. the request is never fully completed. 
It also adds a callback to all incoming requests which counts all 404-responses, grouped by the clients ip address. 

**NBs:**
- The current implementation will not work as expected if multiple instances of the app is run. Then we need to use an actual distributed cache
- The current implementation will not work if the app is placed behind a proxy. Then we need to make sure that the proxy forwards the client ip-address, and that this app uses the [ForwardedHeaders middleware](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.httpoverrides.forwardedheadersmiddleware?view=aspnetcore-10.0).
- We might just want to outsource the rate limiting to the cloud service instead of having it in the code 🤷‍♂️ 

### WHY
To stop pesky crawlers/bots

### HOW
1. Checkout and run this branch
2. Run: `for i in {1..20}; do curl -s -o /dev/null -w "%{http_code}\n" http://localhost:5134/login; done`
3. Verify that you get `429 Responses` after 10 consecutive `404` responses
4. Wait 1 min and try a legit path and verify that it works